### PR TITLE
Define alias `cookie-shuffle-vector` if function is unbound

### DIFF
--- a/poker.el
+++ b/poker.el
@@ -31,6 +31,12 @@
 (require 'cookie1)
 (require 'ert)
 
+;;; Compatibility
+
+(eval-and-compile
+  (unless (fboundp 'cookie-shuffle-vector)
+    (defalias 'cookie-shuffle-vector 'shuffle-vector)))
+
 ;;; Constants:
 
 (defconst poker-ranks '(2 3 4 5 6 7 8 9 10 jack queen king ace))


### PR DESCRIPTION
Required for current stable Emacs release 24.3.1
