### PR TITLE
fix invalid implementation of `poker-possible-hands'

### DIFF
--- a/poker.el
+++ b/poker.el
@@ -107,21 +107,25 @@ The highest possible value is therefore #x8CBA98 and the lowest is #x053210."
 	  (cl-sort (mapcar (lambda (hand) (cons (poker-hand-value hand) hand)) hands)
 		   #'> :key #'car)))
 
+(defun poker-combinations (m lst)
+  "list of all unique ways of taking m different elements from lst"
+  (cond
+   ((= 0 m) '(()))
+   ((null lst) '())
+   (t
+    (append
+     (mapcar
+      (lambda (y) (cons (car lst) y))
+      (comb (1- m) (cdr lst)))
+     (comb m (cdr lst))))))
+
 (defun poker-possible-hands (cards)
   "Generate a list of possible 5 card poker hands from CARDS.
 CARDS is a list of 5 to 7 poker cards."
-  (let ((length (length cards)) (hands ()))
-    (cond
-     ((= length 7)
-      (dolist (card1 cards hands)
-	(dolist (card2 cards)
-	  (unless (eq card1 card2)
-	    (push (cl-remove-if (lambda (card)
-				  (or (eq card card1) (eq card card2)))
-				cards) hands)))))
-     ((= length 6) (dolist (card cards hands) (push (remq card cards) hands)))
-     ((= length 5) (list cards))
-     (t (error "Invalid number of cards")))))
+  (let ((length (length cards)))
+    (if (and (<= length 7) (>= length 5))
+	(poker-combinations 5 cards)
+      (error "Invalid number of cards"))))
 
 (defun poker-best-hand (cards)
   "Find the best hand for a number of CARDS (usually a list of 6 or 7 elements)."


### PR DESCRIPTION
Use generic `poker-combinations' as helper function.
The previous defination returned each 5 card combination of 7 cards twice:

```
ELISP> (length (poker-possible-hands '(1 2 3 4 5 6 7)))
42
ELISP> (length (delete-dups (poker-possible-hands '(1 2 3 4 5 6 7))))
21
```

Also the new implementations is a little bit faster. Old:

```
ELISP> (benchmark  100000 '(poker-possible-hands '(1 2 3 4 5 6 7)))
"Elapsed time: 44.918057s (17.714416s in 209 GCs)"
```

New:

```
ELISP> (benchmark  100000 '(poker-possible-hands '(1 2 3 4 5 6 7)))
"Elapsed time: 22.029148s (8.856341s in 98 GCs)"
```
